### PR TITLE
issue #45 #37

### DIFF
--- a/src/limits.i
+++ b/src/limits.i
@@ -26,8 +26,8 @@
 % Modification Log
 
 % v11.0 Initial revision, revised from FreeTXL 10.8b (c) 1988-2022 Queen's University at Kingston
-
 % v11.2 Changed stack limit message to only when verbose_p
+% v11.3 Added handling of nolimit parse time option
 
 
 % Turing+ Limits
@@ -126,7 +126,11 @@ const * maxLeftRecursion := 10
 
 % Maximum parsing cycles in any parse
 % Normally should allow for the length of the whole input file
-const * maxParseCycles := min (1000000 + 100 * maxTokens, 500000000)
+var vmaxParseCycles :=  min (1000000 + 100 * maxTokens, 500000000)
+if options.option (nolimit_p) then
+    vmaxParseCycles := 2000000000   % almost 2**31 - 1
+end if
+const * maxParseCycles := vmaxParseCycles
 
 % Maximum number of alternatives in a choice or elements in a sequence
 const * maxDefineKids := 65535  % nat2

--- a/src/options.i
+++ b/src/options.i
@@ -29,6 +29,7 @@
 %       Retired old ".Txl" and ".Grm" source file conventions 
 
 % v11.3 Add -p[rogress] virtual option (information messages), default to -q[uiet]
+%       Add -t option, umlimit parse and transform time
 
 
 % TXL option flags
@@ -67,7 +68,8 @@ const * newline_p := 34
 const * case_p := 35
 const * multiline_p := 36
 const * nlcomments_p := 37
-const * lastOption := 37
+const * nolimit_p := 38
+const * lastOption := 38
 
 % TXL program exit code
 var exitcode := 0
@@ -238,6 +240,7 @@ module options
             put : 0, "  -tabnl           [TAB_nn] may force line wrap (default no)"
             put : 0, "  -xml             Output as XML parse tree"
             put : 0, "  -s <size>        Expand TXL tree space memory to <size> Mb (default 32)"
+            put : 0, "  -t               Unlimit parse time"
             put : 0, "  -analyze         Analyze grammar and rule set for ambiguities (slow)"
             put : 0, "  -u               Show TXL tree space memory usage statistics"
             put : 0, "  -o <file>        Write output to <file> (default standard output)"
@@ -360,6 +363,10 @@ module options
             option (charinput_p) := not setting
             option (raw_p) := option (charinput_p)
 
+        elsif optionchar = 't' and optionchar2 = ' ' then
+            % -t
+            option (nolimit_p) := true
+
         elsif optionchar = 'c' and optionchar2 = 'h' then
             % -ch[ar]
             option (charinput_p) := setting
@@ -418,6 +425,10 @@ module options
             % -tx[l]
             option (txl_p) := setting
 
+        elsif optionchar = 't' and optionchar2 = ' ' then
+            % -t
+            option (nolimit_p) := setting
+
         elsif optionchar = 'i' and optionchar2 = 'n' then
             % -in[dent] <indentwidth>
             argnum += 1
@@ -434,7 +445,7 @@ module options
                 option (indent_p) := setting
             end if
 
-        elsif optionchar = 'u' and optionchar2 = 'u' then
+        elsif optionchar = 'u' and optionchar2 = 'p' then
             % -up[percase]
             option (upper_p) := setting
 

--- a/src/txl.t
+++ b/src/txl.t
@@ -50,12 +50,14 @@
 %       Fixed minor memory leaks
 %       Fixed serious bug in skipping rules
 %       Fixed problems with single user installation
+%       Fixed handling of escape chars in predefined functions
+%       Added nolimit parse time option -t
 
 % Global symbols granted to child modules
 include "globals.i"
 
 % TXL version
-const * version := "OpenTxl v11.3.5 (29.5.24) (c) 2024 James R. Cordy and others"
+const * version := "OpenTxl v11.3.6 (10.12.24) (c) 2024 James R. Cordy and others"
 
 % Phase
 const * INITIALIZE := 0

--- a/src/xform-predef.i
+++ b/src/xform-predef.i
@@ -25,10 +25,9 @@
 % Modification Log
 
 % v11.0 Initial revision, revised from FreeTXL 10.8b (c) 1988-2022 Queen's University at Kingston
-
 % v11.1 Added new predifined function [faccess]
-
 % v11.2 Added new shallow extract [^/]
+% v11.3 Fixed handling of escape chars in longstrings
 
 module predefs
     import 
@@ -150,7 +149,8 @@ module predefs
                 var len := length (text)
                 loop
                     exit when ix > len
-                    if type (longstring, text) (ix) = escapeChar and ix < len and type (longstring, text) (ix+1) = quoteChar then
+                    if type (longstring, text) (ix) = escapeChar and ix < len 
+                            and (type (longstring, text) (ix+1) = quoteChar or type (longstring, text) (ix+1) = escapeChar) then
                         for i : ix + 1 .. len + 1       % (sic!)
                             type (longstring, text) (i-1) := type (longstring, text) (i)
                         end for
@@ -183,7 +183,7 @@ module predefs
                 loop
                     exit when len = maxLineLength - 2
                     exit when ix > len
-                    if type (longstring, text) (ix) = quoteChar then
+                    if type (longstring, text) (ix) = quoteChar or type (longstring, text) (ix) = escapeChar then
                         for decreasing i : len + 1 .. ix        % (sic!)
                             type (longstring, text) (i+1) := type (longstring, text) (i)
                         end for


### PR DESCRIPTION
Fixed problem with escape characters in predefined functions (#45). 
Added -t flag to unlimit parse time (#37).
Decided that error message does not need change (#37).