### PR TITLE
Make cross-compilation easier

### DIFF
--- a/src/makefiles/c/Makefile
+++ b/src/makefiles/c/Makefile
@@ -13,9 +13,10 @@
 # most optimizing C compilers to generate incorrect code for it, or at 
 # the very least to slow it down severely, at higher levels of optimization.
 
-CC = gcc -w -Wno-error=int-conversion 
-CFLAGS = -c -O -fno-inline -I .
+CC = gcc
+CFLAGS = -w -Wno-error=int-conversion -c -O -fno-inline -I .
 LD = gcc
+STRIP = strip
 LDFLAGS =
 LDLIBS = -lm
 RLFLAGS = -r 
@@ -52,12 +53,14 @@ else ifeq ($(OS), CYGWIN)
 
 else ifeq ($(OS), MSYS)
     MESSAGE = "Making TXL on Msys / MinGW using gcc and BSD signal handling"
+    CFLAGS := $(CFLAGS) -DWIN
     LDFLAGS := $(LDFLAGS) -Wl,--stack,0x2000000
     EXE = .exe
     SIGTYPE = BSD
 
 else ifeq ($(OS), MINGW64)
     MESSAGE = "Making TXL on Msys / MinGW using gcc and BSD signal handling"
+    CFLAGS := $(CFLAGS) -DWIN
     LDFLAGS := $(LDFLAGS) -Wl,--stack,0x2000000
     EXE = .exe
     SIGTYPE = BSD
@@ -89,18 +92,18 @@ alltxls : thetxl thetxldb thetxlpf thetxlvm thetxlcvt thetxlapr
 thetxl : bin objs objs/main.o objs/txl.o objs/xform.o objs/parse.o objs/loadstor.o ${OBJS} ${TLOBJS} 
 	${CC} ${LDFLAGS} -o bin/txl objs/main.o objs/txl.o objs/xform.o objs/parse.o objs/loadstor.o \
 	    ${OBJS} ${TLOBJS} ${LDLIBS}
-	strip bin/txl${EXE}
+	$(STRIP) bin/txl${EXE}
 	cp scripts/unix/* bin/
 
 thetxldb : bin objs objs/main.o objs/txl.o objs/xformdb.o objs/parse.o objs/loadstor.o ${OBJS} ${TLOBJS} 
 	${CC} ${LDFLAGS} -o bin/txldb objs/main.o objs/txl.o objs/xformdb.o objs/parse.o objs/loadstor.o \
 	    ${OBJS} ${TLOBJS} ${LDLIBS}
-	strip bin/txldb${EXE}
+	$(STRIP) bin/txldb${EXE}
 
 thetxlpf : lib objs objs/main.o objs/txl.o objs/xformpf.o objs/parsepf.o objs/loadstor.o ${OBJS} ${TLOBJS}
 	${CC} ${LDFLAGS} -o lib/txlpf.x objs/main.o objs/txl.o objs/xformpf.o objs/parsepf.o objs/loadstor.o \
 	    ${OBJS} ${TLOBJS} ${LDLIBS}
-	strip lib/txlpf.x
+	$(STRIP) lib/txlpf.x
 
 thetxlvm : lib objs objs/main.o objs/txlsa.o objs/xform.o objs/loadsa.o objs/parsa.o ${COMMONOBJS} ${TLOBJS} 
 	${LD} ${RLFLAGS} -o lib/txlvm.o objs/txlsa.o objs/xform.o objs/loadsa.o objs/parsa.o \
@@ -109,11 +112,11 @@ thetxlvm : lib objs objs/main.o objs/txlsa.o objs/xform.o objs/loadsa.o objs/par
 
 thetxlcvt : lib objs objs/main.o objs/txlcvt.o
 	${CC} ${LDFLAGS} -o lib/txlcvt.x objs/main.o objs/txlcvt.o ${TLOBJS} ${LDLIBS}
-	strip lib/txlcvt.x
+	$(STRIP) lib/txlcvt.x
 
 thetxlapr : lib objs objs/main.o objs/txlapr.o
 	${CC} ${LDFLAGS} -o lib/txlapr.x objs/main.o objs/txlapr.o ${TLOBJS} ${LDLIBS}
-	strip lib/txlapr.x
+	$(STRIP) lib/txlapr.x
 
 objs/main.o : tpluslib/TL.h UNIX main.c 
 	${CC} $(CFLAGS) -D${SIGTYPE} main.c; mv main.o objs/main.o
@@ -216,4 +219,3 @@ clean :
 	rm -f bin/txl* objs/*.o 
 	rm -rf opentxl opentxl-* opentxl*.tar.gz 
 	cd test; make clean; cd ..
-

--- a/src/scripts/c/unix/txl2c
+++ b/src/scripts/c/unix/txl2c
@@ -20,7 +20,8 @@ then
 fi
 
 # Localization
-CC="gcc"
+CC="${CC:-cc}"
+BUILD_TXLLIB="${BUILD_TXLLIB:-$TXLLIB}"
 
 case `uname -s` in
     CYGWIN*|MSYS*|MINGW64*)
@@ -90,7 +91,7 @@ then
 fi
 
 # Convert TXLVM byte code to initialized C byte array
-$TXLLIB/txlcvt.x $TXLNAME.ctxl
+$BUILD_TXLLIB/txlcvt.x $TXLNAME.ctxl
 
 # Clean up
 /bin/rm -f $TXLNAME.ctxl Txl/$TXLNAME.ctxl txl/$TXLNAME.ctxl 2> /dev/null

--- a/src/scripts/c/unix/txl2c
+++ b/src/scripts/c/unix/txl2c
@@ -19,16 +19,7 @@ then
     exit 99
 fi
 
-# Localization
-CC="${CC:-cc}"
 BUILD_TXLLIB="${BUILD_TXLLIB:-$TXLLIB}"
-
-case `uname -s` in
-    CYGWIN*|MSYS*|MINGW64*)
-        CC="$CC -Wl,--stack,0x20000000";;
-    *)
-	;;
-esac
 
 # Decode TXL program name and options
 TXLPROG=""

--- a/src/scripts/c/unix/txlc
+++ b/src/scripts/c/unix/txlc
@@ -20,9 +20,12 @@ then
 fi
 
 # Localization
-CC="gcc"
+CC="${CC:-cc}"
+BUILD_TXLLIB="${BUILD_TXLLIB:-$TXLLIB}"
+TARGET_TXLLIB="${TARGET_TXLLIB:-$TXLLIB}"
+OS="${OS:-$(uname -s)}"
 
-case `uname -s` in
+case "$OS" in
     CYGWIN*|MSYS*|MINGW64*)
         CC="$CC -Wl,--stack,0x20000000";;
     *)
@@ -90,10 +93,10 @@ then
 fi
 
 # Convert TXLVM byte code to initialized C byte array
-$TXLLIB/txlcvt.x $TXLNAME.ctxl
+$BUILD_TXLLIB/txlcvt.x $TXLNAME.ctxl
 
 # Compile and link with TXLVM
-$CC -O -w -o $TXLNAME.x $TXLLIB/txlmain.o $TXLLIB/txlvm.o  ${TXLNAME}_TXL.c -lm
+$CC -O -w -o $TXLNAME.x $TARGET_TXLLIB/txlmain.o $TARGET_TXLLIB/txlvm.o  ${TXLNAME}_TXL.c -lm
 
 # Clean up
 /bin/rm -f $TXLNAME.ctxl Txl/$TXLNAME.ctxl txl/$TXLNAME.ctxl ${TXLNAME}_TXL.* 2> /dev/null

--- a/src/scripts/c/unix/txlp
+++ b/src/scripts/c/unix/txlp
@@ -19,6 +19,8 @@ then
     exit 99
 fi
 
+BUILD_TXLLIB="${BUILD_TXLLIB:-$TXLLIB}"
+
 # Decode TXL program name and options
 TXLFILES=""
 TXLOPTIONS=""
@@ -43,7 +45,7 @@ done
 # Run the TXL command, using txlpf
 if [ "$1" != "" ]
 then
-if  ! $TXLLIB/txlpf.x $* > /dev/null 2> /tmp/txlp$$ 
+if  ! $BUILD_TXLLIB/txlpf.x $* > /dev/null 2> /tmp/txlp$$
 then
 	echo "txlp:  TXL program failed" 2>&1
 	cat /tmp/txlp$$ 2>&1
@@ -54,7 +56,7 @@ then
 fi
 
 # Analyze the results
-$TXLLIB/txlapr.x $PROFOPTIONS
+$BUILD_TXLLIB/txlapr.x $PROFOPTIONS
 
 # Clean up
 /bin/rm -f /tmp/txlp$$


### PR DESCRIPTION
This PR makes a handful of small changes to help make cross-compilation easier. Specifically:

1. Flags that were previously part of the `CC` variable were moved to the start of `CFLAGS`, so that setting a custom compiler does not make compilation fail due to the lack of `-Wno-error=int-conversion`.
   It also defines a `STRIP` option, so that the `strip` binary can be similarly overridden.

   These changes make it easier to cross-compile _OpenTxl itself_ to other platforms. For example:

   ```sh
   $ make csrc
   $ cd csrc
   $ make CC=aarch64-linux-gnu-gcc LD=aarch64-linux-gnu-gcc STRIP=aarch64-linux-gnu-strip
   ```

2. It allows using a custom C compiler for `txlc`, as well as passing different `TXLLIB` directories to use for the build system vs. the target system. The build system's `BUILD_TXLLIB` is used for any files that need to be executed at build time (in particular `txlcvt.x`), while the target system's `TARGET_TXLLIB` is used to provide Txl `.o` files for the target architecture. The default is to use the standard `cc` compiler, and to use the same `TXLLIB` for both build and target.

   These changes make it easier to cross-compile _Txl programs_ to other platforms. For example, one could compile a Txl program on an x86-64 build system to run on an AArch64 (ARM) target system like so:

   ```sh
   $ CC=aarch64-linux-gnu-gcc BUILD_TXLLIB=/path/to/host/txl/lib TARGET_TXLLIB=/path/to/aarch64/txl/lib txlc program.txl
   ```

   Where the AArch64 lib files could themselves come from cross-compiling OpenTxl to AArch64.