### PR TITLE
Wildcard support for rule names in debugger

### DIFF
--- a/src/ident.i
+++ b/src/ident.i
@@ -34,7 +34,9 @@ module ident
     import error, var tree
 
     export idents, identKind, identTree, nIdents, nilIdent, 
-        identText, nIdentChars, install, lookup, setKind
+        identText, nIdentChars, install, lookup, setKind,
+        identPatternLookup, startPatternLookup, lookupNextPattern,
+        isIdentPattern
 
     const * nilIdent := 0       % we use the hash code for ASCII NUL (chr(0)) as the nil identifier
 
@@ -125,6 +127,88 @@ module ident
     
         result identIndex
     end lookup
+
+    % Used for sequential identifier lookup with wildcards
+    type identPatternKind : enum (matchAny, matchStart, matchEnd, matchMiddle)
+
+    type identPatternLookup :
+        record
+            currentIndex : int  % Current index in idents
+            patternString : string  % The pattern itself
+            patternKind: identPatternKind
+        end record
+
+    % Return true if the identifier matches the pattern
+    function identPatternMatches (patternLookup : identPatternLookup, ident : string) : boolean
+        bind pattern to patternLookup.patternString
+        var pattLen := length (pattern)
+        var identLen := length (ident)
+        case patternLookup.patternKind of
+            label identPatternKind.matchAny :
+                result true
+            label identPatternKind.matchStart :
+                result identLen >= pattLen - 1
+                   and ident (identLen - (pattLen - 2) .. identLen) = pattern (2 .. pattLen)
+            label identPatternKind.matchEnd :
+                result identLen >= pattLen - 1
+                   and ident (1 .. pattLen - 1) = pattern(1 .. pattLen - 1)
+            label identPatternKind.matchMiddle :
+                var i := index (pattern, '*')
+                var pattLeft := pattern (1 .. i - 1)
+                var pattRight := pattern (i + 1 .. pattLen)
+                result identLen >= pattLen - 1
+                   and ident (1 .. length (pattLeft)) = pattLeft
+                   and ident (identLen - length (pattRight) + 1 .. identLen) = pattRight
+        end case
+        result false
+    end identPatternMatches
+
+    function isIdentPattern (pattern : string) : boolean
+        % Can't start with '\'' and contains a '*'
+        result pattern (1) not= '\'' and index (pattern, "*") > 0
+    end isIdentPattern
+
+    function startPatternLookup (pattern : string) : identPatternLookup
+        var patternLookup : identPatternLookup
+        patternLookup.currentIndex := 1  % idents starts at 0, but first is nilIdent
+        patternLookup.patternString := pattern
+        % Start - "*foo"
+        if pattern (1) = '*' then
+            if length (pattern) = 1 then
+                patternLookup.patternKind := identPatternKind.matchAny
+            else
+                patternLookup.patternKind := identPatternKind.matchStart
+            end if
+        % End - "foo*"
+        elsif pattern (length(pattern)) = '*' then
+            patternLookup.patternKind := identPatternKind.matchEnd
+        % Middle - "foo*bar"
+        else
+            patternLookup.patternKind := identPatternKind.matchMiddle
+        end if
+
+        result patternLookup
+    end startPatternLookup
+
+    function lookupNextPattern (var patternLookup : identPatternLookup) : tokenT
+        var startIndex := patternLookup.currentIndex
+
+        var register identIndex : nat := 0
+        var numMatches : nat := 0
+
+        for i : startIndex .. maxIdents - 1
+            if idents (i) not= nilIdent then
+               var ident := string@(idents (i))
+               if identPatternMatches (patternLookup, string@(idents (i))) then
+                   patternLookup.currentIndex := i + 1
+                   result i
+               end if
+            end if
+        end for
+
+        patternLookup.currentIndex := 1  % Reset
+        result NOT_FOUND
+    end lookupNextPattern
 
     % Install an identifier in the identifier table and return its index.
     % Begin with the hash of the identifier, then add the secondary hash modulo table size until we find it

--- a/src/xform-debug.i
+++ b/src/xform-debug.i
@@ -82,7 +82,7 @@ module debugger
         end loop
 
         if bp > nbreakpoints then
-            put : 0, "  ? Rule not being breakpointed"
+            put : 0, "  ? Rule not being breakpointed ", string@(ident.idents (ruleName))
             return
         end if
 
@@ -115,6 +115,16 @@ module debugger
             result isrealbreakpoint (ruleName)
         end if
     end isbreakpoint
+
+    function findruleindex (ruleName : tokenT) : nat
+        for r : 1 .. rule.nRules
+            if rule.rules (r).name = ruleName then
+                result r
+            elsif r = rule.nRules then
+                result 0
+	    end if
+        end for
+    end findruleindex
 
     procedure findruleordefine (sourceFileName, sourceDirectory : string, rdId : string,
             var rdfilename : string, var rdline : int)
@@ -609,17 +619,15 @@ module debugger
                 end if
                 
                 var found := false
-                for r : 1..rule.nRules
-                    if rule.rules (r).name = setrulename then
-                        found := true
-                        matchfinding := true
-                        matchrulename := setrulename
-                        exit
-                    elsif r = rule.nRules then
-                        put : 0, "  ? No such rule"
-                        exit
-                    end if
-                end for
+                var ruleIndex : nat := findruleindex (setrulename)
+                if ruleIndex > 0 then
+                    found := true
+                    matchfinding := true
+                    matchrulename := setrulename
+                else
+                    put : 0, "  ? No such rule"
+                    exit
+                end if
                 
                 exit when found
 
@@ -630,16 +638,37 @@ module debugger
                 else
                     ruleId := string@(ident.idents (ruleName))
                 end if
-                const setRuleName := ident.lookup (ruleId)
-                for r : 1..rule.nRules
-                    if rule.rules (r).name = setRuleName then
-                        setbreakpoint (setRuleName)
-                        exit
-                    elsif r = rule.nRules then
-                        put : 0, "  ? No such rule"
-                        exit
+                if ident.isIdentPattern (ruleId) then
+                    var pattern := ident.startPatternLookup (ruleId)
+                    var ruleFound := false
+                    loop
+                        var setRuleName := ident.lookupNextPattern (pattern)
+                        exit when setRuleName = ident.nilIdent
+
+                        if setRuleName not= ident.nilIdent then
+                            var r := findruleindex (setRuleName)
+                            if r > 0 then
+                                setbreakpoint (setRuleName)
+                                ruleFound := true
+                            end if
+                        end if
+                    end loop
+                    if not ruleFound then
+                        put : 0, "  ? No rule matching pattern ", ruleId
                     end if
-                end for
+                else
+                    % Trim quote, if one exists
+                    if ruleId (1) = '\'' then
+                        ruleId := ruleId (2 .. *)
+                    end if
+                    const setRuleName := ident.lookup (ruleId)
+                    var r := findruleindex (setRuleName)
+                    if r > 0 then
+                        setbreakpoint (setRuleName)
+                    else
+                        put : 0, "  ? No such rule ", ruleId
+                    end if
+                end if
 
             elsif command = "clear" or command = "clr" 
                     or index (command, "clear ") = 1  or index (command, "clr ") = 1 then
@@ -650,16 +679,35 @@ module debugger
                 else
                     ruleId := string@(ident.idents (ruleName))
                 end if
-                const clearRuleName := ident.lookup (ruleId)
-                for r : 1..rule.nRules
-                    if rule.rules (r).name = clearRuleName then
-                        clearbreakpoint (clearRuleName)
-                        exit
-                    elsif r = rule.nRules then
-                        put : 0, "  ? No such rule"
-                        exit
+                if ident.isIdentPattern (ruleId) then
+                    var pattern := ident.startPatternLookup (ruleId)
+                    var ruleFound := false
+                    loop
+                        var clearRuleName := ident.lookupNextPattern (pattern)
+                        exit when clearRuleName = ident.nilIdent
+
+                        var r := findruleindex (clearRuleName)
+                        if r > 0 then
+                            clearbreakpoint (clearRuleName)
+                            ruleFound := true
+                        end if
+                    end loop
+                    if not ruleFound then
+                        put : 0, "  ? No rule matching pattern ", ruleId
                     end if
-                end for
+                else
+                    % Trim quote, if one exists
+                    if ruleId (1) = '\'' then
+                        ruleId := ruleId (2 .. *)
+                    end if
+                    const clearRuleName := ident.lookup (ruleId)
+                    var r := findruleindex (clearRuleName)
+                    if r > 0 then
+                        clearbreakpoint (clearRuleName)
+                    else
+                        put : 0, "  ? No such rule ", ruleId
+                    end if
+                end if
 
             elsif command = "showbps" then
                 var outlength := 0

--- a/test/regression/TestAll.sh
+++ b/test/regression/TestAll.sh
@@ -4,15 +4,15 @@
 # J.R. Cordy, October 2022
 
 # The TXLs to compare
-OLDTXL=/usr/local/bin/txl
-NEWTXL=../../bin/txl
+OLDTXL=${OLDTXL:-/usr/local/bin/txl}
+NEWTXL=${NEWTXL:-../../bin/txl}
 
-if [ ! -x $OLDTXL ]; then
+if [[ ! -x $OLDTXL ]]; then
     echo "ERROR: No installed TXL to compare to ($OLDTXL)"
     exit 1
 fi
 
-if [ ! -x $NEWTXL ]; then
+if [[ ! -x $NEWTXL ]]; then
     echo "ERROR: No new TXL to compare to ($NEWTXL - did you remember to build it?)"
     exit 1
 fi
@@ -29,38 +29,34 @@ echo "==== TESTING ===="
 success=true
 
 # For all of the tests in the regression set
-dirs=`/bin/ls`
-
-for dir in $dirs; do
-    if [ -d $dir ]; then
-        cd $dir
+for dir in ./*; do
+    if [[ -d $dir ]]; then
+        cd "$dir"
 
         # For each example input
-        egs=`/bin/ls eg*.*`
-
-        for eg in $egs; do
+        for eg in ./eg*.*; do
             # Run old TXL
             : > /tmp/tta-old$$
-            (/usr/bin/time $OLDTXL -v -s 400 -w 200 $eg -o /tmp/tta-old$$ < /tmp/42 2>&1 ) >> $eg-oldoutput
-            cat /tmp/tta-old$$ >> $eg-oldoutput
-            grep "TXL0" $eg-oldoutput >> /tmp/tta-old$$
+            (/usr/bin/time "$OLDTXL" -v -s 400 -w 200 "$eg" -o /tmp/tta-old$$ < /tmp/42 2>&1 ) >> "$eg"-oldoutput
+            cat /tmp/tta-old$$ >> "$eg"-oldoutput
+            grep "TXL0" "$eg"-oldoutput >> /tmp/tta-old$$
 
             # Run new TXL
             : > /tmp/tta-new$$
-            (/usr/bin/time ../$NEWTXL -v -s 400 -w 200 $eg -o /tmp/tta-new$$ < /tmp/42 2>&1 ) >> $eg-newoutput
-            cat /tmp/tta-new$$ >> $eg-newoutput
-            grep "TXL0" $eg-newoutput >> /tmp/tta-new$$
+            (/usr/bin/time ../$NEWTXL -v -s 400 -w 200 "$eg" -o /tmp/tta-new$$ < /tmp/42 2>&1 ) >> "$eg"-newoutput
+            cat /tmp/tta-new$$ >> "$eg"-newoutput
+            grep "TXL0" "$eg"-newoutput >> /tmp/tta-new$$
 
             # Diff them
-            if [ "`diff -q /tmp/tta-old$$ /tmp/tta-new$$`" != "" ]; then
+            if [[ $(diff -q /tmp/tta-old$$ /tmp/tta-new$$) != "" ]]; then
                 echo "** Output for $dir/$eg differs"
                 success=false
             fi
 
             # Diff detailed performance if requested
-            if [ "$1" == "performance" ]; then
+            if [[ $1 == "performance" ]]; then
                 echo "==== $dir/$eg ===="
-                diff $eg-oldoutput $eg-newoutput
+                diff "$eg"-oldoutput "$eg"-newoutput
             fi
         done
         cd ..
@@ -68,7 +64,7 @@ for dir in $dirs; do
 done
 
 # Report results
-if [ "$success" == "true" ]; then
+if [[ $success == "true" ]]; then
     echo "==== SUCCEEDED ===="
 else
     echo "==== FAILED ===="


### PR DESCRIPTION
This adds wildcard matching in the debugger for `set` and `clear`.

A single * can be used in a rule name to match any number of characters. If somehow
the rule contains a *, a leading single quote "escapes" the entire string.

Example output:
```
$ bin/txldb ~/Downloads/Txl/eg.OOTstub test/regression/OOT/txl/OOTstub.txl
[test/regression/OOT/txl/OOTstub.txl] : TXL0206W define 'declarationOrStatement' - (Warning) Define overrides previous declaration ('redefine' should be used if override intended)
TXLDB >> set *ments
  Breakpoint set at rule removeExportComments
  Breakpoint set at rule removeStatements
  Breakpoint set at rule removeComments
TXLDB >> clear remove*
  Breakpoint cleared at rule removeExportComments
  ? Rule not being breakpointed removeDuplicates
  Breakpoint cleared at rule removeStatements
  Breakpoint cleared at rule removeComments
  ? Rule not being breakpointed removeMarks
TXLDB >> set remove*s
  Breakpoint set at rule removeExportComments
  Breakpoint set at rule removeDuplicates
  Breakpoint set at rule removeStatements
  Breakpoint set at rule removeComments
  Breakpoint set at rule removeMarks
TXLDB >> set '*
  Breakpoint set at rule *
```